### PR TITLE
Quick fix to spacing of code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const User = props => (
 )
 
 const Greeting = props => (
-	<p class="greeting" translate="yes">
+  <p class="greeting" translate="yes">
     Hello, <User name="Bob" />!
   </p>
 );


### PR DESCRIPTION
Just noticed the indentation was off in one of the code examples in the README as I was reading through.